### PR TITLE
Fix grid issue with features

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -138,7 +138,7 @@ export default function Index() {
           />
         </div>
       </div>
-      <dl className="space-y-8 md:space-y-0 md:grid md:grid-cols-2 xl:grid-cols-3 md:gap-x-8 md:gap-y-8">
+      <dl className="space-y-8 auto-rows-min md:space-y-0 md:grid md:grid-cols-2 xl:grid-cols-3 md:gap-x-8 md:gap-y-8">
         <Feature icon={BeakerIcon} title="100% customizable UI">
           Create custom inputs and use the default UI for everything else.
         </Feature>


### PR DESCRIPTION
Adding auto-rows-min so that height of the features extends to the minimum of the content. This is currently causing a visual bug where the footer is overlapping the features at larger viewports.

<img width="1256" alt="Screen Shot 2022-03-08 at 12 26 34 AM" src="https://user-images.githubusercontent.com/708820/157179507-02b5e8f0-a743-4225-8e5a-e70a4c56ec6d.png">