### PR TITLE
Add relevant imports to the code sample in home page

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -25,7 +25,11 @@ const description =
 
 export const meta: MetaFunction = () => metaTags({ title, description })
 
-const code = `const schema = z.object({
+const code = `import { z } from 'zod'
+import { makeDomainFunction } from 'remix-domains'
+import { formAction, Form } from 'remix-forms'
+
+const schema = z.object({
   firstName: z.string().nonempty(),
   email: z.string().nonempty().email(),
   howYouFoundOutAboutUs: z.enum(['fromAFriend', 'google']),


### PR DESCRIPTION
I felt a little lost when looking at the home sample code for the first time.
I recon the imports might help to clarify things like the `<Form />` not being the `@remix-run/react form` and that we are using `zod`, etc.

Hope it helps