### PR TITLE
UI adjustments

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -38,7 +38,7 @@ export const links: LinksFunction = () => {
 
 export default function App() {
   return (
-    <html lang="en" className="h-full">
+    <html lang="en" className="h-full overflow-x-hidden">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -46,7 +46,7 @@ export default function App() {
         <Meta />
         <Links />
       </head>
-      <body className="flex h-full w-full flex-col overflow-y-auto overflow-x-hidden bg-gradient-to-r from-gray-900 to-gray-600 antialiased scrollbar-thin scrollbar-track-gray-500 scrollbar-thumb-gray-700">
+      <body className="flex min-h-screen w-screen max-w-[100vw] flex-col overflow-y-auto overflow-x-hidden bg-gradient-to-r from-gray-900 to-gray-600 antialiased scrollbar-thin scrollbar-track-gray-500 scrollbar-thumb-gray-700">
         <TopBar />
         <main className="flex flex-1 flex-col">
           <Outlet />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,6 +7,7 @@ import {
   Scripts,
   ScrollRestoration,
 } from '@remix-run/react'
+import colors from 'tailwindcss/colors'
 import styles from './styles/app.css'
 import highlightStyles from 'highlight.js/styles/a11y-dark.css'
 import favicon from './favicon.png'
@@ -41,6 +42,7 @@ export default function App() {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta name="theme-color" content={colors.gray[900]}></meta>
         <Meta />
         <Links />
       </head>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -46,15 +46,15 @@ export default function App() {
         <Meta />
         <Links />
       </head>
-      <body className="antialiased h-full w-full overflow-x-hidden overflow-y-auto bg-gradient-to-r from-gray-900 to-gray-600 scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-gray-500">
+      <body className="flex h-full w-full flex-col overflow-y-auto overflow-x-hidden bg-gradient-to-r from-gray-900 to-gray-600 antialiased scrollbar-thin scrollbar-track-gray-500 scrollbar-thumb-gray-700">
         <TopBar />
-        <div className="min-h-[86.5vh]">
+        <main className="flex flex-1 flex-col">
           <Outlet />
-        </div>
-        <div className="bg-gradient-to-r from-black to-gray-800 text-center text-white p-4">
+        </main>
+        <footer className="bg-gradient-to-r from-black to-gray-800 p-4 text-center text-white">
           Built with ❤️💪🏼 by{' '}
           <ExternalLink href="https://seasoned.cc">Seasoned</ExternalLink>
-        </div>
+        </footer>
         <ScrollRestoration />
         <Scripts />
         <LiveReload />

--- a/app/routes/examples.tsx
+++ b/app/routes/examples.tsx
@@ -4,7 +4,7 @@ import SidebarLayout from '~/ui/sidebar-layout'
 
 export default function Component() {
   return (
-    <div className="min-h-[86.5vh] relative">
+    <div className="relative isolate flex grow flex-col">
       <SidebarLayout>
         <SidebarLayout.Nav>
           <SidebarLayout.NavTitle>Actions</SidebarLayout.NavTitle>
@@ -99,7 +99,7 @@ export default function Component() {
           </SidebarLayout.NavLink>
         </SidebarLayout.Nav>
         <SidebarLayout.Content>
-          <div className="flex flex-col space-y-4 sm:space-y-8 text-gray-200 p-4 sm:p-8">
+          <div className="flex flex-col space-y-4 p-4 text-gray-200 sm:space-y-8 sm:p-8">
             <Outlet />
           </div>
         </SidebarLayout.Content>

--- a/app/routes/get-started.tsx
+++ b/app/routes/get-started.tsx
@@ -142,7 +142,7 @@ export default function Component() {
   } = useLoaderData()
 
   return (
-    <div className="flex flex-col space-y-8 max-w-2xl m-auto text-gray-200 px-4 py-8 sm:px-8 sm:py-16">
+    <div className="m-auto flex max-w-2xl flex-col space-y-8 px-4 py-8 text-gray-200 sm:px-8 sm:py-16">
       <Heading>Get Started</Heading>
       <SubHeading>Dependencies</SubHeading>
       <p>

--- a/app/ui/code.tsx
+++ b/app/ui/code.tsx
@@ -9,7 +9,10 @@ export default function Code({
   return (
     <Pre
       {...props}
-      className={cx('xl:flex-1 max-h-[60vh]', className)}
+      className={cx(
+        'max-h-[60vh] max-w-[calc(100vw-2rem)] xl:flex-1',
+        className,
+      )}
       dangerouslySetInnerHTML={{ __html: children }}
     />
   )

--- a/app/ui/pre.tsx
+++ b/app/ui/pre.tsx
@@ -8,7 +8,7 @@ export default function Pre({
     <pre
       {...props}
       className={cx(
-        'bg-black font-mono text-white p-2 overflow-auto text-xs sm:text-sm scrollbar-thin scrollbar-thumb-gray-800 scrollbar-track-gray-600 rounded',
+        'max-w-[calc(100vw-2rem)] overflow-auto  rounded bg-black p-2 font-mono text-xs text-white scrollbar-thin scrollbar-track-gray-600 scrollbar-thumb-gray-800 sm:text-sm',
         className,
       )}
     />

--- a/app/ui/sidebar-layout.tsx
+++ b/app/ui/sidebar-layout.tsx
@@ -22,7 +22,7 @@ function Nav({ children, type = 'disclosure', close, ...props }: NavProps) {
     <Panel as="nav" {...props}>
       <div className={cx('w-[12rem] bg-pink-600 p-2 pb-4', classes)}>
         <div className="flex justify-end p-1">
-          <Button className="inline-flex items-center justify-center p-1 rounded-md text-pink-900 hover:text-white hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+          <Button className="inline-flex items-center justify-center rounded-md p-1 text-pink-900 hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
             <Icon className="block h-6 w-6" />
           </Button>
         </div>
@@ -44,7 +44,7 @@ function Nav({ children, type = 'disclosure', close, ...props }: NavProps) {
 
 function NavTitle({ className, ...props }: JSX.IntrinsicElements['h4']) {
   return (
-    <h4 className={cx('text-pink-900 font-medium', className)} {...props} />
+    <h4 className={cx('font-medium text-pink-900', className)} {...props} />
   )
 }
 
@@ -90,9 +90,9 @@ function Closed({ type }: { type: SidebarType }) {
   const Button = type === 'disclosure' ? Disclosure.Button : Popover.Button
 
   return (
-    <div className={cx('bg-pink-600 absolute inset-y-0 p-1 w-10')}>
-      <div className="h-full relative">
-        <Button className="sticky top-0 inline-flex items-center justify-center p-1 rounded-md text-pink-900 hover:text-white hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+    <div className={cx('absolute inset-y-0 w-10 bg-pink-600 p-1 md:relative')}>
+      <div className="relative h-full">
+        <Button className="sticky top-0 inline-flex items-center justify-center rounded-md p-1 text-pink-900 hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
           <MenuAlt2Icon className="block h-6 w-6" />
         </Button>
       </div>
@@ -133,7 +133,7 @@ function SidebarRoot({
       <Disclosure
         as="div"
         defaultOpen
-        className={cx('hidden md:flex', className)}
+        className={cx('hidden grow md:flex', className)}
         {...props}
       >
         {({ open, close }) => (

--- a/app/ui/top-bar.tsx
+++ b/app/ui/top-bar.tsx
@@ -24,7 +24,7 @@ export default function TopBar() {
       {({ open, close }) => (
         <>
           <header>
-            <div className="flex w-full items-center space-x-2 sm:space-x-4">
+            <div className="flex items-center gap-2 sm:gap-4">
               <div className="flex-1">
                 <div className="flex shrink-0 items-center">
                   <Link to={$path('/')} className="block h-10 w-10">

--- a/app/ui/top-bar.tsx
+++ b/app/ui/top-bar.tsx
@@ -23,10 +23,10 @@ export default function TopBar() {
     >
       {({ open, close }) => (
         <>
-          <div>
-            <div className="w-full flex items-center space-x-2 sm:space-x-4">
+          <header>
+            <div className="flex w-full items-center space-x-2 sm:space-x-4">
               <div className="flex-1">
-                <div className="flex-shrink-0 flex items-center">
+                <div className="flex shrink-0 items-center">
                   <Link to={$path('/')} className="block h-10 w-10">
                     <img
                       src={logo}
@@ -51,7 +51,7 @@ export default function TopBar() {
                 <GitHub />
               </ExternalLink>
               <div className="flex items-center sm:hidden">
-                <Popover.Button className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+                <Popover.Button className="inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
                   <span className="sr-only">Open main menu</span>
                   {open ? (
                     <XIcon className="block h-6 w-6" aria-hidden="true" />
@@ -61,10 +61,10 @@ export default function TopBar() {
                 </Popover.Button>
               </div>
             </div>
-          </div>
+          </header>
 
           <Popover.Panel className="sm:hidden">
-            <div className="px-2 pt-4 pb-2 space-y-1 sm:px-3">
+            <div className="space-y-1 px-2 pt-4 pb-2 sm:px-3">
               {navigation.map((item) => (
                 <NavLink
                   key={item.name}
@@ -74,7 +74,7 @@ export default function TopBar() {
                       isActive
                         ? 'bg-gray-900 text-white'
                         : 'text-gray-300 hover:bg-gray-700 hover:text-white',
-                      'block px-3 py-2 rounded-md text-base font-medium',
+                      'block rounded-md px-3 py-2 text-base font-medium',
                     )
                   }
                   onClick={() => close()}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,11 @@
         "@types/lodash": "^4.14.178",
         "@types/react": "^17.0.24",
         "@types/react-dom": "^17.0.9",
+        "@types/tailwindcss": "^3.0.10",
         "autoprefixer": "^10.4.2",
         "concurrently": "^7.0.0",
         "postcss": "^8.4.6",
+        "prettier-plugin-tailwindcss": "^0.1.10",
         "tailwind-scrollbar": "^1.3.1",
         "tailwindcss": "^3.0.23",
         "typescript": "^4.5.5"
@@ -2533,6 +2535,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
+    "node_modules/@types/tailwindcss": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/tailwindcss/-/tailwindcss-3.0.10.tgz",
+      "integrity": "sha512-1UnZIHO0NOPyPlPFV0HuMjki2SHkvG9uBA1ZehWj/OQMSROk503nuNyyfmJSIT289yewxTbKoPG+KLxYRvfIIg==",
       "dev": true
     },
     "node_modules/@types/unist": {
@@ -9313,6 +9321,18 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.10.tgz",
+      "integrity": "sha512-ooDGNuXUjgCXfShliVYQ6+0iXqUFXn+zdNInPe0WZN9qINt9srbLGFGY5jeVL4MXtY20/4S8JaBcd8l6N6NfCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
@@ -13965,6 +13985,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
+    "@types/tailwindcss": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/tailwindcss/-/tailwindcss-3.0.10.tgz",
+      "integrity": "sha512-1UnZIHO0NOPyPlPFV0HuMjki2SHkvG9uBA1ZehWj/OQMSROk503nuNyyfmJSIT289yewxTbKoPG+KLxYRvfIIg==",
       "dev": true
     },
     "@types/unist": {
@@ -18770,6 +18796,13 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
       "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
       "dev": true
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.10.tgz",
+      "integrity": "sha512-ooDGNuXUjgCXfShliVYQ6+0iXqUFXn+zdNInPe0WZN9qINt9srbLGFGY5jeVL4MXtY20/4S8JaBcd8l6N6NfCQ==",
+      "dev": true,
+      "requires": {}
     },
     "pretty-ms": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
     "@types/lodash": "^4.14.178",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
+    "@types/tailwindcss": "^3.0.10",
     "autoprefixer": "^10.4.2",
     "concurrently": "^7.0.0",
     "postcss": "^8.4.6",
+    "prettier-plugin-tailwindcss": "^0.1.10",
     "tailwind-scrollbar": "^1.3.1",
     "tailwindcss": "^3.0.23",
     "typescript": "^4.5.5"


### PR DESCRIPTION
This PR:
- improves a little bit the HTML semantics
- adds meta "theme-color" to get this a cool effect on top bar in Safari and Mobile devices
- fixes a UI bug when menu was closed on big screens
- pushes the footer to the bottom of the page even in huge screens
- adds tailwind's prettier plugin to sort out TW classes automatically (might be out of context, sorry)

# Before:
![Captura_de_Tela_2022-05-04_às_10_53_26](https://user-images.githubusercontent.com/566971/166696683-6469ff9c-b7bf-4d45-8a73-7efbffa59307.jpg)

# After:
![Captura de Tela 2022-05-04 às 10 53 36](https://user-images.githubusercontent.com/566971/166696719-14c22a97-9157-4c26-b84f-ea56814a8569.png)

