### PR TITLE
Improve menu contrast ratio

### DIFF
--- a/app/ui/sidebar-layout.tsx
+++ b/app/ui/sidebar-layout.tsx
@@ -22,7 +22,7 @@ function Nav({ children, type = 'disclosure', close, ...props }: NavProps) {
     <Panel as="nav" {...props}>
       <div className={cx('w-[14rem] bg-pink-600 p-2 pb-4', classes)}>
         <div className="flex justify-end p-1">
-          <Button className="inline-flex items-center justify-center rounded-md p-1 text-gray-900 hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+          <Button className="inline-flex items-center justify-center rounded-md p-1 text-[#480803] hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
             <Icon className="block h-6 w-6" />
           </Button>
         </div>
@@ -44,7 +44,7 @@ function Nav({ children, type = 'disclosure', close, ...props }: NavProps) {
 
 function NavTitle({ className, ...props }: JSX.IntrinsicElements['h4']) {
   return (
-    <h4 className={cx('font-medium text-gray-900', className)} {...props} />
+    <h4 className={cx('font-medium text-[#480803]', className)} {...props} />
   )
 }
 
@@ -92,7 +92,7 @@ function Closed({ type }: { type: SidebarType }) {
   return (
     <div className={cx('absolute inset-y-0 w-10 bg-pink-600 p-1 md:relative')}>
       <div className="relative h-full">
-        <Button className="sticky top-0 inline-flex items-center justify-center rounded-md p-1 text-gray-900 hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+        <Button className="sticky top-0 inline-flex items-center justify-center rounded-md p-1 text-[#480803] hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
           <MenuAlt2Icon className="block h-6 w-6" />
         </Button>
       </div>

--- a/app/ui/sidebar-layout.tsx
+++ b/app/ui/sidebar-layout.tsx
@@ -22,7 +22,7 @@ function Nav({ children, type = 'disclosure', close, ...props }: NavProps) {
     <Panel as="nav" {...props}>
       <div className={cx('w-[14rem] bg-pink-600 p-2 pb-4', classes)}>
         <div className="flex justify-end p-1">
-          <Button className="inline-flex items-center justify-center rounded-md p-1 text-pink-900 hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+          <Button className="inline-flex items-center justify-center rounded-md p-1 text-gray-900 hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
             <Icon className="block h-6 w-6" />
           </Button>
         </div>
@@ -44,7 +44,7 @@ function Nav({ children, type = 'disclosure', close, ...props }: NavProps) {
 
 function NavTitle({ className, ...props }: JSX.IntrinsicElements['h4']) {
   return (
-    <h4 className={cx('font-medium text-pink-900', className)} {...props} />
+    <h4 className={cx('font-medium text-gray-900', className)} {...props} />
   )
 }
 
@@ -92,7 +92,7 @@ function Closed({ type }: { type: SidebarType }) {
   return (
     <div className={cx('absolute inset-y-0 w-10 bg-pink-600 p-1 md:relative')}>
       <div className="relative h-full">
-        <Button className="sticky top-0 inline-flex items-center justify-center rounded-md p-1 text-pink-900 hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+        <Button className="sticky top-0 inline-flex items-center justify-center rounded-md p-1 text-gray-900 hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
           <MenuAlt2Icon className="block h-6 w-6" />
         </Button>
       </div>


### PR DESCRIPTION
The recommended contrast ratio for regular text is 4.5. We went from 2.09 to 3.85

Before
<img width="299" alt="Screen Shot 2022-05-18 at 10 33 58" src="https://user-images.githubusercontent.com/6249611/169051406-4873b37d-c91e-45f7-ba76-b0a6a35eb3f4.png">


After
<img width="309" alt="Screen Shot 2022-05-18 at 10 33 35" src="https://user-images.githubusercontent.com/6249611/169051481-a558239b-9413-4f24-a8c9-08d9582f9ebf.png">


<img width="104" alt="Screen Shot 2022-05-18 at 10 31 44" src="https://user-images.githubusercontent.com/6249611/169051535-82f8242a-511b-4708-a591-5027fdc3ee8a.png">
<img width="219" alt="Screen Shot 2022-05-18 at 10 31 30" src="https://user-images.githubusercontent.com/6249611/169051552-228bb453-909f-4416-91c2-d30a8593ee75.png">

