### PR TITLE
Fix navbar position

### DIFF
--- a/app/ui/sidebar-layout.tsx
+++ b/app/ui/sidebar-layout.tsx
@@ -20,7 +20,7 @@ function Nav({ children, type = 'disclosure', close, ...props }: NavProps) {
 
   return (
     <Panel as="nav" {...props}>
-      <div className={cx('w-[14rem] bg-pink-600 p-2 pb-4', classes)}>
+      <div className={cx('z-10 w-[14rem] bg-pink-600 p-2 pb-4', classes)}>
         <div className="flex justify-end p-1">
           <Button className="inline-flex items-center justify-center rounded-md p-1 text-[#480803] hover:bg-pink-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
             <Icon className="block h-6 w-6" />


### PR DESCRIPTION
Before:
<img width="312" alt="Screen Shot 2022-05-19 at 14 14 42" src="https://user-images.githubusercontent.com/6249611/169359083-21de5e92-7ab8-48f9-9e82-bd1c17645c68.png">

After:
<img width="304" alt="Screen Shot 2022-05-19 at 14 14 35" src="https://user-images.githubusercontent.com/6249611/169359062-fa2e9d7e-019d-4606-8361-2f5f88203722.png">

Quick and dirty with z-index since it isn't a production app.
